### PR TITLE
a simple hack contain bouncing issue

### DIFF
--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/utils/Utils.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/utils/Utils.java
@@ -52,8 +52,7 @@ public class Utils {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     public static boolean isRtl(Resources res) {
-        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) &&
-                (res.getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL);
+        return res.getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
     }
 
     public static Bitmap drawableToBitmap(Drawable drawable) {

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
@@ -374,15 +374,16 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
         }
 
         View child = getChildAt(0);
-        stateOut.rowIndex = getChildAdapterPosition(child);
 
         // don't do anything if we have a header item
-        if (getLayoutManager().getChildAt(0).getHeight() < getLayoutManager().getChildAt(1).getHeight()) { // identify header
+        if (child.getHeight() < getLayoutManager().getChildAt(1).getHeight()) { // identify header
             stateOut.rowHeight = lastRowHeight;
             stateOut.rowIndex = lastRowIndex;
             stateOut.rowTopOffset = lastTopOffset;
             return;
         }
+
+        stateOut.rowIndex = getChildAdapterPosition(child);
 
         if (getLayoutManager() instanceof GridLayoutManager) {
             stateOut.rowIndex = stateOut.rowIndex / ((GridLayoutManager) getLayoutManager()).getSpanCount();
@@ -395,6 +396,8 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
                 > getLayoutManager().getChildAt(1).getHeight()
                 ? getLayoutManager().getChildAt(0).getHeight()
                 : getLayoutManager().getChildAt(1).getHeight();
+
+        // saves last state when not headers
         lastRowHeight = stateOut.rowHeight;
         lastTopOffset = stateOut.rowTopOffset;
         lastRowIndex = stateOut.rowIndex;

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScrollRecyclerView.java
@@ -374,7 +374,6 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
         }
 
         View child = getChildAt(0);
-
         // don't do anything if we have a header item
         if (child.getHeight() < getLayoutManager().getChildAt(1).getHeight()) { // identify header
             stateOut.rowHeight = lastRowHeight;
@@ -382,9 +381,7 @@ public class FastScrollRecyclerView extends RecyclerView implements RecyclerView
             stateOut.rowTopOffset = lastTopOffset;
             return;
         }
-
         stateOut.rowIndex = getChildAdapterPosition(child);
-
         if (getLayoutManager() instanceof GridLayoutManager) {
             stateOut.rowIndex = stateOut.rowIndex / ((GridLayoutManager) getLayoutManager()).getSpanCount();
         }

--- a/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
+++ b/recyclerview-fastscroll/src/main/java/com/simplecityapps/recyclerview_fastscroll/views/FastScroller.java
@@ -355,6 +355,11 @@ public class FastScroller {
         mRecyclerView.invalidate(mInvalidateRect);
     }
 
+    public void setTrackColor(@ColorInt int color) {
+        if (mTrack != null) mTrack.setColor(color);
+        mRecyclerView.invalidate(mInvalidateRect);
+    }
+
     public void setPopupBgColor(@ColorInt int color) {
         if (mTrack != null) mTrack.setColor(color);
         mPopup.setBgColor(color);


### PR DESCRIPTION
When taking on this problem, I see that before we did not use the measurable interface for the recyclerView provided by this library, but the scroller works pretty well compared to the the one that implemented the interface. The reason is with the latest version of the library, there is still no implementation of a measurable variant for GridView. Thus, I decided to use this hack to contain the jumps of the scroll bars. Since everything is int based, there are still some jumps when under the day section we have 2 or 1 empty item on a role. Any suggestion for a better fix?

branch for testing: https://github.com/MonumentLabs/m-android/tree/haomin/bugfix/1482/boncing_scrollbar

Before:
![oldhaha](https://user-images.githubusercontent.com/2370877/51566779-226df700-1e5b-11e9-9aa6-df7ed98966d8.gif)

After:
![newhaha](https://user-images.githubusercontent.com/2370877/51566929-81cc0700-1e5b-11e9-90ae-00a6ed985535.gif)
